### PR TITLE
try/catch for average rating

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -65,7 +65,7 @@ class Product(SafeDeleteModel):
 
         try:
             avg = total_rating / len(ratings)
-        except:
+        except ZeroDivisionError:
             avg = 0
             
         return avg

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -59,10 +59,15 @@ class Product(SafeDeleteModel):
         """
         ratings = ProductRating.objects.filter(product=self)
         total_rating = 0
+
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        try:
+            avg = total_rating / len(ratings)
+        except:
+            avg = 0
+            
         return avg
 
     class Meta:


### PR DESCRIPTION
Added a Try/Exception that sets the `avg` variable to 0 if the `ZeroDivisionError` appears when there are no ratings associated with the requested product.

## Changes

- Try to create the average rating
- If `ZeroDivisionError` is thrown, the exception sets `avg` to 0 before continuing

## Testing

- [x] GET `/products/50`
``` json
{
  "id": 50,
  "name": "Escalade EXT",
  "price": 926.92,
  "number_sold": 2,
  "description": "2008 Cadillac",
  "quantity": 2,
  "created_date": "2019-02-01",
  "location": "Lokavec",
  "image_path": null,
  "average_rating": 3.25
}
```
Expected Response: `200 OK`

- [x] GET `products/2`
```json
{
    "id": 2,
    "name": "Golf",
    "price": 653.59,
    "number_sold": 0,
    "description": "1994 Volkswagen",
    "quantity": 4,
    "created_date": "2019-07-10",
    "location": "Zhongshan",
    "image_path": null,
    "average_rating": 0
}
```
Expected Response: `200 OK`

## Related Issue

- Fixes #11 