### PR TITLE
update current_user to pull the current authed user

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -61,7 +61,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user__id=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             serializer = ProfileSerializer(current_user, many=False, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:


### PR DESCRIPTION
Originally, the line that assigned the `current_user` variable to the Customer instance was only matching with `user_id` of 4. Updated it to match the currently authed user with a Customer instance.

## Changes

- Update the filter for the `current_user` variable to match the `Customer` instance with the currently authed user.

## Testing

- [x] GET request at `/profile`
- [x] Do another GET request at `/profile`, but first change the `Token` in the header to another user to see the data returned change to match that currently authed user.

## Related Issues

- Fixes #4 