### PR TITLE
update if/else to check for greater than or equal to

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -266,7 +266,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
The issue was that getting products with the `number_sold` query was checking for products with a **less than or equal to** number sold when it needed to be a **greater than or equal to** number sold.

## Changes

- Update `sort_filter` function to `>=` instead of `<=`

## Testing

- [x] `POST` to `/products?number_sold=2` to see products with 2 or more sales

## Related Issues

- Fixes #5