### PR TITLE
payment method create now puts exp and create date in the correct place

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
When running a `GET` for `paymenttypes`, the Expiration Date & Create Dates were switched. This is because the `create` method on `paymenttypes` was mapping `newpayment.create_date` to the passed `expiration_date` request data and vice versa.

## Changes

- Switched request data mapping in paymenttype `create` method to match correctly for `create_date` & `expiration_date`

## Requests / Responses

**Request**

POST `/paymenttypes` Creates a new payment

```json
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 Created

```json
{
    "id": 7,
    "url": "http://localhost:8000/paymenttypes/7",
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

## Testing

Description of how to test code...

- [x] `POST` a new payment type to `/paymenttypes`

## Related Issues

- Fixes #7 