### PR TITLE
update listing paymenttypes and only print current user's

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        if customer.id is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
This PR includes changes to the listing of `paymenttypes` to only display the payment types created by the signed-in user. I created a `customer` variable that pulls the Customer instance that matches the authenticated user. The filtering is the same, it just filters for the `customer_id` matching the `customer.id` from that instance.

## Changes

- Update the `customer_id` variable to pull Customer instance matching the authenticated user instead of the customer id passed through a query

## Requests / Responses

**Request**

GET `/paymenttypes` Gets all payment types by the authenticated users

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 7,
        "url": "http://localhost:8000/paymenttypes/7",
        "merchant_name": "Amex",
        "account_number": "000000000000",
        "expiration_date": "2023-12-12",
        "create_date": "2020-12-12"
    }
]
```

>This is the payment types only for the customer with the id of 4

## Testing

- [x] `GET` request at `/paymenttypes` to ensure only payment types from the authenticated user is returned.

## Related Issues

- Fixes #8 