### PR TITLE
add location query with __contain filter

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -242,12 +242,16 @@ class Products(ViewSet):
         """
         products = Product.objects.all()
 
-        # Support filtering by category and/or quantity
+        # Support filtering by category, location, and/or quantity
         category = self.request.query_params.get('category', None)
         quantity = self.request.query_params.get('quantity', None)
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        location = self.request.query_params.get('location', None)
+
+        if location is not None:
+            products = Product.objects.filter(location__contains=location)
 
         if order is not None:
             order_filter = order


### PR DESCRIPTION
This PR adds a `location` query parameter when getting products by a location. If the query is used in a request, the response holds all products with a location that contains the text in the query.

## Changes

- Add `location` query parameter.
- If the `location` query is used in the request, it filters for products that contain the query in their location.

## Requests / Responses

**Request**

GET `/products?location=ong` Gets all products that have a location containing "ong" in it.

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 2,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Zhongshan",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 27,
        "name": "Range Rover",
        "price": 1564.25,
        "number_sold": 0,
        "description": "2002 Land Rover",
        "quantity": 1,
        "created_date": "2019-05-14",
        "location": "Yong’an",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

- [x] Run a `GET` request at `/products?location=ong`

## Related Issues

- Fixes #12