### PR TITLE
create and retrieve ratings and test those too

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -18,6 +18,7 @@ router.register(r'orders', Orders, 'order')
 router.register(r'cart', Cart, 'cart')
 router.register(r'paymenttypes', Payments, 'payment')
 router.register(r'profile', Profile, 'profile')
+router.register(r'ratings', ProductRatings, 'rating')
 
 
 # Wire up our API using automatic URL routing.

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -9,3 +9,4 @@ from .productcategory import ProductCategories
 from .lineitem import LineItems
 from .customer import Customers
 from .user import Users
+from .productrating import ProductRatings

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -16,8 +16,8 @@ class ProductSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         fields = ('id', 'name', 'price', 'number_sold', 'description',
-                  'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+                    'quantity', 'created_date', 'location', 'image_path',
+                    'average_rating', 'can_be_rated', )
         depth = 1
 
 

--- a/bangazonapi/views/productrating.py
+++ b/bangazonapi/views/productrating.py
@@ -1,0 +1,40 @@
+from django.core.exceptions import ValidationError
+from django.http.response import HttpResponseServerError
+from rest_framework import status
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from bangazonapi.models import ProductRating, Customer, Product
+
+class ProductRatingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProductRating
+        fields = ('id', 'customer', 'product', 'rating')
+
+
+class ProductRatings(ViewSet):
+
+    def list(self, request):
+        ratings = ProductRating.objects.all()
+
+        serializer = ProductRatingSerializer(
+            ratings, many=True, context={'request': request}
+        )
+
+        return Response(serializer.data)
+
+    def create(self, request):
+
+        product = Product.objects.get(pk=request.data['product'])
+
+        productrating = ProductRating()
+        productrating.rating = request.data['rating']
+        productrating.customer = Customer.objects.get(user=request.auth.user)
+        productrating.product = product
+
+        try:
+            productrating.save()
+            serializer = ProductRatingSerializer(productrating, context={'request': request})
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        except ValidationError as ex:
+            return Response({'reason': ex.message}, status=status.HTTP_400_BAD_REQUEST)

--- a/tests/product.py
+++ b/tests/product.py
@@ -116,7 +116,7 @@ class ProductTests(APITestCase):
             json_response = json.loads(response.content)
 
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-            self.assertEqual(json_response["rating"], x + 1)
+            self.assertEqual(json_response["rating"], data['rating'])
             self.assertEqual(json_response["product"], 1)
         
         response = self.client.get(product_url, None, format="json")

--- a/tests/product.py
+++ b/tests/product.py
@@ -95,6 +95,34 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
-    # TODO: Delete product
+    def test_rate_product(self):
+        """
+        Ensure that a rating can be added to a product and verify that the avg_rating key exists.
+        """
+        self.test_create_product()
 
-    # TODO: Product can be rated. Assert average rating exists.
+        ratings_url = "/ratings"
+        product_url = "/products/1"
+        data = {
+            "rating": 1,
+            "product": 1,
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        for x in range(1,4):
+            data['rating'] += 1
+            response = self.client.post(ratings_url, data, format='json')
+            json_response = json.loads(response.content)
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(json_response["rating"], x + 1)
+            self.assertEqual(json_response["product"], 1)
+        
+        response = self.client.get(product_url, None, format="json")
+        json_response = json.loads(response.content)
+        
+        self.assertEqual(json_response["average_rating"], 3.0)
+
+
+    # TODO: Delete product


### PR DESCRIPTION
This PR includes the addition of a `ratings` viewset that will list all ratings and allow the user to create a new rating at the `/ratings` URL. To complete the PR, a test was created that `POST`s 3 new ratings to the same product, then verifies the `average_rating` pulled from that product is expected.

## Changes

- New `ratings` view that retrieves and creates ratings
- New URL endpoint at `/ratings`
- New `test_rate_product` test that creates 3 ratings for the same product so an accurate average can be tested

## Requests / Responses

**Request**

POST `/ratings` Creates a new rating

```json
{
    "product": 32,
    "rating": 8
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 6,
    "customer": 7,
    "product": 32,
    "rating": 8
}
```

>`customer` and `id` will of course be different depending on your number of ratings at the time of posting and the authenticated user.

## Testing

- [x] Run `POST` at `/ratings` with the data in the `request` above
- [x] Run `GET` at `/ratings` to view all ratings
- [x] Run `python manage.py test tests -v 1` in your terminal to ensure all 7 tests pass (which includes `test_rate_product`)


## Related Issues

- Fixes #19

>I know there were a few ways to create ratings, and I went back and forth on trying to create a rating with the `products` URL, but based on how I did it with `gamerrater` I didn't think that was necessary here.