### PR TITLE
test adding payment type to open order

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -20,7 +20,7 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
+                    'expiration_date', 'create_date')
 
 
 class Payments(ViewSet):

--- a/tests/order.py
+++ b/tests/order.py
@@ -92,13 +92,18 @@ class OrderTests(APITestCase):
         """
         self.test_add_product_to_order()
 
-        url = "/order/1"
+        url = "/orders/1"
         data = { "payment_type": 1 }
 
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        response = self.client.get(url, data, format='json')
         json_response = json.loads(response.content)
-        print(json_response)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(json_response["payment_type"].split('/')[-1]), 1)
 
 
     # TODO: New line item is not added to closed order

--- a/tests/order.py
+++ b/tests/order.py
@@ -29,6 +29,13 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        # Create a payment type
+        url = "/paymenttypes"
+        data = { "merchant_name": "Ryan", "account_number": 12345678, "create_date": "2020-03-01", "expiration_date": "2023-03-01" }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
 
     def test_add_product_to_order(self):
         """
@@ -79,6 +86,19 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["size"], 0)
         self.assertEqual(len(json_response["lineitems"]), 0)
 
-    # TODO: Complete order by adding payment type
+    def test_add_payment_to_order(self):
+        """
+        Ensure we can add a payment type to an order so it can be completed
+        """
+        self.test_add_product_to_order()
+
+        url = "/order/1"
+        data = { "payment_type": 1 }
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+        json_response = json.loads(response.content)
+        print(json_response)
+
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
This PR has a new test that adds a `payment_type` to a new order then checks the response when getting back the order is correct.

## Changes

- New test called `test_add_payment_to_order` that adds a `payment_type` to the open order.
- After running a `PUT` to add the `payment_type`, a `GET` is run to verify the response has the `payment_type`.
- `setUp` in `tests/order.py` now creates a `payment_type`.

## Testing

- [ ] Run ` python manage.py test tests -v 1` and all 8 tests should pass

>The response returned `http://testserver/paymenttypes/1` instead of just `1`, so I created a split on `/` to get just the id at the end of the URL generated by the serializer.

## Related Issues

- Fixes #15